### PR TITLE
feat: add diff playlist creation

### DIFF
--- a/src/main/kotlin/de/dargmuesli/spotilist/providers/util/SpotifyUtil.kt
+++ b/src/main/kotlin/de/dargmuesli/spotilist/providers/util/SpotifyUtil.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.javafx.JavaFx
 import kotlinx.coroutines.javafx.JavaFxDispatcher
 import kotlinx.coroutines.launch
 import se.michaelthelin.spotify.SpotifyApi
+import se.michaelthelin.spotify.enums.AuthorizationScope
 import se.michaelthelin.spotify.exceptions.detailed.BadRequestException
 import se.michaelthelin.spotify.requests.data.AbstractDataPagingRequest
 import java.awt.Desktop
@@ -65,6 +66,7 @@ object SpotifyUtil : CoroutineScope {
     fun authorize() {
         if (SpotifyConfig.authorizationCode.value.isNullOrEmpty()) {
             val authorizationCodeUri = spotifyApi.authorizationCodeUri()
+                .scope(AuthorizationScope.PLAYLIST_MODIFY_PRIVATE)
                 .build().execute()
 
             launch(Dispatchers.IO) {

--- a/src/main/kotlin/de/dargmuesli/spotilist/ui/controllers/DashboardController.kt
+++ b/src/main/kotlin/de/dargmuesli/spotilist/ui/controllers/DashboardController.kt
@@ -1,17 +1,28 @@
 package de.dargmuesli.spotilist.ui.controllers
 
+import com.google.gson.Gson
+import com.google.gson.JsonParser
 import de.dargmuesli.spotilist.MainApp
 import de.dargmuesli.spotilist.models.PlaylistMapping
+import de.dargmuesli.spotilist.models.music.Track
 import de.dargmuesli.spotilist.persistence.SpotilistConfig
+import de.dargmuesli.spotilist.providers.SpotilistProviderType
+import de.dargmuesli.spotilist.providers.provider.SpotifyProvider
+import de.dargmuesli.spotilist.providers.util.SpotifyUtil.spotifyApi
 import de.dargmuesli.spotilist.ui.SpotilistStage
+import de.dargmuesli.spotilist.util.Util
 import javafx.collections.ListChangeListener
+import javafx.event.ActionEvent
 import javafx.fxml.FXML
 import javafx.fxml.FXMLLoader
 import javafx.fxml.Initializable
 import javafx.scene.control.Accordion
+import javafx.scene.control.Button
 import javafx.stage.Modality
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import se.michaelthelin.spotify.model_objects.AbstractModelObject
+import java.io.File
 import java.net.URL
 import java.util.*
 
@@ -22,6 +33,9 @@ class DashboardController : Initializable {
 
     @FXML
     private lateinit var playlistMappingsAccordion: Accordion
+
+    @FXML
+    private lateinit var reportGenerateButton: Button
 
     override fun initialize(url: URL?, rb: ResourceBundle?) {
         SpotilistConfig.playlistMappings.addListener(ListChangeListener { playlistMappingChange ->
@@ -58,5 +72,191 @@ class DashboardController : Initializable {
         playlistMappingsAccordion.panes.forEach {
             LOGGER.info(it.content)
         }
+    }
+
+    fun generateReport(actionEvent: ActionEvent) {
+        LOGGER.info("Searching Spotify playlist tracks in local filesystem:")
+
+        SpotilistConfig.playlistMappings.forEach { playlistMapping ->
+            val sourcePlaylist =
+                SpotilistProviderType.valueOf(playlistMapping.sourceResource.provider.value).type.getPlaylist(
+                    playlistMapping.sourceResource.id.value
+                ) ?: return@forEach
+
+            if (!arrayOf("Liked Songs").contains(sourcePlaylist.name)) {
+                return@forEach
+            }
+
+            val targetPlaylist =
+                SpotilistProviderType.valueOf(playlistMapping.targetResource.provider.value).type.getPlaylist(
+                    playlistMapping.targetResource.id.value
+                ) ?: return@forEach
+
+            val sourceTracks = sourcePlaylist.tracks
+            val targetNames = targetPlaylist.tracks?.map { track ->
+                track.artists?.let { artists ->
+                    Util.getValidFilename(artists.map { it.name }.joinToString()) + " - "
+                } + Util.getValidFilename(track.name ?: "")
+            }?.toHashSet() ?: return@forEach
+
+            val notFound = sourceTracks?.filter {
+                !targetNames.contains(
+                    it.artists?.let { artists ->
+                        Util.getValidFilename(artists.map { it.name }.joinToString()) + " - "
+                    } + Util.getValidFilename(it.name ?: "")
+                )
+            }
+
+            if (notFound == null || notFound.isEmpty()) {
+                LOGGER.info("All found in \"${sourcePlaylist.name}\" (${sourcePlaylist.tracks?.size})!")
+            } else {
+                LOGGER.info(
+                    "In \"${sourcePlaylist.name}\" (${sourcePlaylist.tracks.size}), but not in \"${targetPlaylist.name}\" (${targetPlaylist.tracks.size}):\n${
+                        notFound.joinToString(
+                            "\n"
+                        ) { it.name + " (" + it.id + ")" }
+                    }"
+                )
+
+                if (arrayOf("Liked Songs").contains(sourcePlaylist.name)) {
+                    val currentUserProfile = spotifyApi.currentUsersProfile.build().execute()
+                    val playlist =
+                        spotifyApi.createPlaylist(currentUserProfile.id, "TODO (Date)").public_(false).build().execute()
+                    notFound.map { "spotify:track:" + it.id }.chunked(100).forEach { chunk ->
+                        spotifyApi.addItemsToPlaylist(playlist.id, JsonParser.parseString(Gson().toJson(chunk)).asJsonArray).build().execute()
+                    }
+                }
+            }
+        }
+
+        LOGGER.info("Searching Spotify playlist tracks in other playlists:")
+
+        SpotilistConfig.playlistMappings.forEachIndexed { index, playlistMapping ->
+            val sourcePlaylist =
+                SpotilistProviderType.valueOf(playlistMapping.sourceResource.provider.value).type.getPlaylist(
+                    playlistMapping.sourceResource.id.value
+                ) ?: return@forEachIndexed
+
+            if (arrayOf("Liked Songs").contains(sourcePlaylist.name)) {
+                return@forEachIndexed
+            }
+
+            LOGGER.info("Comparing \"${sourcePlaylist.name}\" (${sourcePlaylist.tracks?.size}):")
+
+            SpotilistConfig.playlistMappings.forEachIndexed { indexInner, playlistMappingInner ->
+                if (index <= indexInner || playlistMapping.sourceResource.id.value == playlistMappingInner.sourceResource.id.value) {
+                    return@forEachIndexed
+                }
+
+                val targetPlaylist =
+                    SpotilistProviderType.valueOf(playlistMappingInner.sourceResource.provider.value).type.getPlaylist(
+                        playlistMappingInner.sourceResource.id.value
+                    ) ?: return@forEachIndexed
+
+                if (arrayOf("Liked Songs").contains(targetPlaylist.name)) {
+                    return@forEachIndexed
+                }
+
+                val sourceNames = sourcePlaylist.tracks?.map { track ->
+                    track.artists?.let { artists ->
+                        Util.getValidFilename(artists.map { it.name }.joinToString()) + " - "
+                    } + Util.getValidFilename(track.name ?: "")
+                }?.toHashSet() ?: return@forEachIndexed
+                val targetNames = targetPlaylist.tracks?.map { track ->
+                    track.artists?.let { artists ->
+                        Util.getValidFilename(artists.map { it.name }.joinToString()) + " - "
+                    } + Util.getValidFilename(track.name ?: "")
+                }?.toHashSet() ?: return@forEachIndexed
+
+                val found = sourceNames.filter { targetNames.contains(it) }.joinToString("\n")
+
+                if (found.isEmpty()) {
+                    LOGGER.debug("None found in \"${targetPlaylist.name}\" (${targetPlaylist.tracks.size})!")
+                } else {
+                    LOGGER.info("In \"${sourcePlaylist.name}\" (${sourcePlaylist.tracks.size}), but also in \"${targetPlaylist.name}\" (${targetPlaylist.tracks.size}):\n${found}")
+                }
+            }
+        }
+
+        LOGGER.info("Searching liked tracks that are not in any genre playlist:")
+
+        val likedSongsId = "4P9gkeY7Pd8EXn4IijePlE"
+
+        val likedSongsPlaylist = SpotifyProvider.getPlaylist(
+            likedSongsId
+        ) ?: return
+
+        val foundNames = mutableListOf<String>()
+
+        for (playlistMapping in SpotilistConfig.playlistMappings) {
+            // TODO: allow to mark playlists as excluded from comparison
+            if (likedSongsId == playlistMapping.sourceResource.id.value) {
+                continue
+            }
+
+            val targetPlaylist =
+                SpotilistProviderType.valueOf(playlistMapping.sourceResource.provider.value).type.getPlaylist(
+                    playlistMapping.sourceResource.id.value
+                ) ?: continue
+
+            if (arrayOf("Liked Songs").contains(targetPlaylist.name)) {
+                continue
+            }
+
+            val targetNames = targetPlaylist.tracks?.map { track ->
+                track.artists?.let { artists ->
+                    Util.getValidFilename(artists.map { it.name }.joinToString()) + " - "
+                } + Util.getValidFilename(track.name ?: "")
+            }?.toHashSet() ?: continue
+            foundNames.addAll(targetNames)
+        }
+
+        val notFoundNames = mutableListOf<Track>()
+
+        likedSongsPlaylist.tracks?.forEach { track ->
+            val likedSongsName = track.artists?.let { artists ->
+                Util.getValidFilename(artists.map { it.name }.joinToString()) + " - "
+            } + Util.getValidFilename(track.name ?: "")
+
+            if (!foundNames.contains(likedSongsName)) {
+                notFoundNames.add(track)
+            }
+        }
+
+        if (notFoundNames.isEmpty()) {
+            LOGGER.info("All \"Liked Songs\" are in a playlist.")
+        } else {
+            LOGGER.info("In \"Liked Songs\", but not in any playlist:\n${notFoundNames.joinToString("\n") { it.name + " (" + it.id + ")" }}")
+        }
+
+        LOGGER.info("Generating m3u files:")
+
+        for (playlistMapping in SpotilistConfig.playlistMappings) {
+            if (likedSongsId == playlistMapping.sourceResource.id.value) {
+                continue
+            }
+
+            val targetPlaylist =
+                SpotilistProviderType.valueOf(playlistMapping.sourceResource.provider.value).type.getPlaylist(
+                    playlistMapping.sourceResource.id.value
+                ) ?: continue
+
+            if (arrayOf("Liked Songs").contains(targetPlaylist.name)) {
+                continue
+            }
+
+            val targetNames = targetPlaylist.tracks?.map { track ->
+                "M:\\Quellen\\Spotify\\" + track.artists?.let { artists ->
+                    Util.getValidFilename(artists.map { it.name }.joinToString()) + " - "
+                } + Util.getValidFilename(track.name ?: "") + ".mp3"
+            }?.reduce { acc, s -> acc + "\n" + s } ?: continue
+            targetPlaylist.name?.let {
+                File("/run/media/jonas/music/Playlists/Spotilist/" + Util.getValidFilename(it) + ".m3u").writeText(
+                    targetNames
+                )
+            }
+        }
+
+        LOGGER.info("Done!")
     }
 }

--- a/src/main/resources/de/dargmuesli/spotilist/fxml/dashboard.fxml
+++ b/src/main/resources/de/dargmuesli/spotilist/fxml/dashboard.fxml
@@ -23,4 +23,7 @@
         <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#addPlaylistMapping"
                 text="%new"/>
     </VBox>
+    <Button fx:id="reportGenerateButton" mnemonicParsing="false"
+            onAction="#generateReport" text="%reportGenerate" GridPane.columnIndex="1"
+            GridPane.halignment="CENTER" GridPane.rowIndex="4"/>
 </VBox>


### PR DESCRIPTION
This pull request introduces a new feature to generate reports and perform analysis on Spotify playlists, along with some supporting changes. The most significant update is the addition of a `generateReport` function in the `DashboardController`, which provides detailed comparisons of playlist tracks, identifies missing tracks, and generates `.m3u` playlist files. Additionally, the Spotify authorization process is updated to request the correct scope for modifying playlists, and a new button is added to the dashboard UI to trigger report generation.
