### PR TITLE
chore(deps): downgrade jdk to v17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           cache: gradle
           distribution: temurin
-          java-version: 21
+          java-version: 17
       - name: Build with Gradle
         run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ ext {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 
     modularity.inferModulePath = false // https://github.com/openjfx/javafx-gradle-plugin/pull/154/files
 }
@@ -40,7 +40,7 @@ application {
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_21
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use JDK 17 instead of JDK 21 for building the project with Gradle.